### PR TITLE
Update ConfigFileProvider

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -262,7 +262,7 @@ namespace NzbDrone.Core.Configuration
             }
         }
 
-        public string UiFolder => BuildInfo.IsDebug ? Path.Combine("..", "UI") : "UI";
+        public string UiFolder => BuildInfo.IsDebug ? Path.Combine("../..", "UI") : "UI";
 
         public string InstanceName
         {


### PR DESCRIPTION
This pull request modifies the UiFolder property in the ConfigFileProvider.cs file to improve the handling of folder paths during debug builds.

Previously, the path was defined as:
public string UiFolder => BuildInfo.IsDebug ? Path.Combine("..", "UI") : "UI";

This configuration set the UiFolder path to one level above the base directory in debug mode.

The updated implementation changes this to:
public string UiFolder => BuildInfo.IsDebug ? Path.Combine("../..", "UI") : "UI";

This adjustment ensures the path navigates two levels up to accommodate scenarios where the debug environment requires additional directory traversal to locate the UI folder.

This change is aimed at improving compatibility and ensuring the correct resolution of the UI folder during debug builds. It does not affect release builds, where the path remains as "UI".